### PR TITLE
Safer initialization of NcFile objects (BRAINSTORM-1796)

### DIFF
--- a/download/NetCdfStreamer.h
+++ b/download/NetCdfStreamer.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "DataStreamer.h"
-
+#include <memory>
 #include <netcdfcpp.h>
 
 namespace SmartMet
@@ -34,10 +34,11 @@ class NetCdfStreamer : public DataStreamer
 
  private:
   NetCdfStreamer();
+  void requireNcFile();
 
   NcError ncError;
   std::string file;
-  NcFile ncFile;
+  std::unique_ptr<NcFile> ncFile;
   std::ifstream ioStream;
   bool isLoaded;
 


### PR DESCRIPTION
Tests passed apart from the landscaped variables which were already broken.